### PR TITLE
added patches providing an overview of functionality: filter, analysis

### DIFF
--- a/girlpower/ImageAnalysis - Overview.v4p
+++ b/girlpower/ImageAnalysis - Overview.v4p
@@ -1,0 +1,225 @@
+<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45debug31.3.dtd" >
+   <PATCH nodename="C:\Users\joreg\dev\repos\vvvv\public\vvvv45\packs\Image\girlpower\ImageAnalysis - Overview.v4p" systemname="ImageAnalysis - Overview" filename="C:\Users\joreg\dev\repos\vvvv\public\vvvv45\packs\Image\girlpower\ImageAnalysis - Overview.v4p">
+   <BOUNDS type="Window" left="9555" top="4875" width="11520" height="7410">
+   </BOUNDS>
+   <NODE systemname="Renderer (OpenCV)" filename="%VVVV%\packs\Image\nodes\plugins\VVVV.Nodes.OpenCV.dll" nodename="Renderer (OpenCV)" componentmode="InAWindow" id="35">
+   <BOUNDS type="Node" left="5205" top="1935" width="100" height="100">
+   </BOUNDS>
+   <BOUNDS type="Window" left="150" top="1170" width="6240" height="5010">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Slice" slicecount="1" values="0">
+   </PIN>
+   <BOUNDS type="Box" left="5205" top="1935">
+   </BOUNDS>
+   <PIN pinname="Descriptive Name" slicecount="1" values="||">
+   </PIN>
+   </NODE>
+   <NODE systemname="Pipet (OpenCV)" filename="%VVVV%\packs\Image\nodes\plugins\VVVV.Nodes.OpenCV.dll" nodename="Pipet (OpenCV)" componentmode="Hidden" id="0">
+   <BOUNDS type="Node" left="2520" top="3825" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <PIN pinname="Pass original">
+   </PIN>
+   <PIN pinname="Input 2">
+   </PIN>
+   <BOUNDS type="Box" left="2520" top="3825">
+   </BOUNDS>
+   </NODE>
+   <NODE systemname="Framerate (OpenCV)" filename="%VVVV%\packs\Image\nodes\plugins\VVVV.Nodes.OpenCV.dll" nodename="Framerate (OpenCV)" componentmode="Hidden" id="20">
+   <BOUNDS type="Node" left="4020" top="3840" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <BOUNDS type="Box" left="4020" top="3840">
+   </BOUNDS>
+   </NODE>
+   <NODE systemname="Contour (OpenCV)" filename="%VVVV%\packs\Image\nodes\plugins\VVVV.Nodes.OpenCV.dll" nodename="Contour (OpenCV)" componentmode="Hidden" id="21">
+   <BOUNDS type="Node" left="5025" top="3825" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <PIN pinname="Input 2">
+   </PIN>
+   <PIN pinname="Pass original">
+   </PIN>
+   <BOUNDS type="Box" left="5025" top="3825">
+   </BOUNDS>
+   <PIN pinname="Perimeter" visible="1">
+   </PIN>
+   </NODE>
+   <NODE systemname="VideoIn (OpenCV)" filename="%VVVV%\packs\Image\nodes\plugins\VVVV.Nodes.OpenCV.dll" nodename="VideoIn (OpenCV)" componentmode="Hidden" id="17">
+   <BOUNDS type="Node" left="3930" top="885" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <PIN pinname="Filename">
+   </PIN>
+   <PIN pinname="Enabled" slicecount="1" values="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="17" srcpinname="Output" dstnodeid="0" dstpinname="Input">
+   </LINK>
+   <LINK srcnodeid="17" srcpinname="Output" dstnodeid="20" dstpinname="Input">
+   </LINK>
+   <LINK srcnodeid="17" srcpinname="Output" dstnodeid="21" dstpinname="Input">
+   </LINK>
+   <LINK srcnodeid="17" srcpinname="Output" dstnodeid="35" dstpinname="Input">
+   </LINK>
+   <NODE systemname="Change (OpenCV)" nodename="Change (OpenCV)" componentmode="Hidden" id="19" filename="%VVVV%\packs\Image\nodes\plugins\VVVV.Nodes.OpenCV.dll">
+   <BOUNDS type="Node" left="3150" top="3825" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <PIN pinname="Input 2">
+   </PIN>
+   <BOUNDS type="Box" left="3150" top="3825">
+   </BOUNDS>
+   </NODE>
+   <LINK srcnodeid="17" srcpinname="Output" dstnodeid="19" dstpinname="Input">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="37" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="3000" top="3105" width="795" height="480">
+   </BOUNDS>
+   <BOUNDS type="Node" left="3000" top="3105" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="2" values="0.5,0.5">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Vector Size" slicecount="1" values="2">
+   </PIN>
+   <PIN pinname="Rows" slicecount="1" values="2">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="37" srcpinname="Y Output Value" dstnodeid="0" dstpinname="Position px">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="39" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="3075" top="4845" width="795" height="240">
+   </BOUNDS>
+   <BOUNDS type="Node" left="3075" top="4845" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Integer">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="19" srcpinname="Output frames" dstnodeid="39" dstpinname="Y Input Value">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="40" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="1230" top="4785" width="795" height="720">
+   </BOUNDS>
+   <BOUNDS type="Node" left="1230" top="4785" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Rows" slicecount="1" values="3">
+   </PIN>
+   <PIN pinname="Y Input Value">
+   </PIN>
+   <PIN pinname="Vector Size" slicecount="1" values="3">
+   </PIN>
+   <PIN pinname="Default" slicecount="1" values="|0, 0, 0|">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="0" srcpinname="Output" dstnodeid="40" dstpinname="Y Input Value">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="41" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="4245" top="4845" width="795" height="240">
+   </BOUNDS>
+   <BOUNDS type="Node" left="4245" top="4845" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="20" srcpinname="Framerate fps" dstnodeid="41" dstpinname="Y Input Value">
+   </LINK>
+   <NODE systemname="AvgSdv (OpenCV Mean)" filename="%VVVV%\packs\Image\nodes\plugins\VVVV.Nodes.OpenCV.dll" nodename="AvgSdv (OpenCV Mean)" componentmode="Hidden" id="42">
+   <BOUNDS type="Node" left="6495" top="3825" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="17" srcpinname="Output" dstnodeid="42" dstpinname="Input">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="43" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="6495" top="4635" width="795" height="720">
+   </BOUNDS>
+   <BOUNDS type="Node" left="6495" top="4635" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Rows" slicecount="1" values="3">
+   </PIN>
+   <PIN pinname="Y Input Value">
+   </PIN>
+   <PIN pinname="Vector Size" slicecount="1" values="3">
+   </PIN>
+   <PIN pinname="Default" slicecount="1" values="|0, 0, 0|">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="42" srcpinname="Average" dstnodeid="43" dstpinname="Y Input Value">
+   </LINK>
+   <NODE systemname="ObjectTracking (OpenCV)" filename="%VVVV%\packs\Image\nodes\plugins\VVVV.Nodes.OpenCV.dll" nodename="ObjectTracking (OpenCV)" componentmode="Hidden" id="44">
+   <BOUNDS type="Node" left="7860" top="3810" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="17" srcpinname="Output" dstnodeid="44" dstpinname="Input">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="45" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="7890" top="4710" width="795" height="480">
+   </BOUNDS>
+   <BOUNDS type="Node" left="7890" top="4710" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Vector Size" slicecount="1" values="2">
+   </PIN>
+   <PIN pinname="Rows" slicecount="1" values="2">
+   </PIN>
+   <PIN pinname="Y Input Value">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="44" srcpinname="PositionXY" dstnodeid="45" dstpinname="Y Input Value">
+   </LINK>
+   <NODE systemname="ContourDelauney (OpenCV)" filename="%VVVV%\packs\Image\nodes\plugins\VVVV.Nodes.OpenCV.dll" nodename="ContourDelauney (OpenCV)" componentmode="Hidden" id="46">
+   <BOUNDS type="Node" left="5535" top="5670" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="21" srcpinname="Perimeter" dstnodeid="46" dstpinname="Input">
+   </LINK>
+   <NODE systemname="ContourPerimeter (OpenCV Split)" filename="%VVVV%\packs\Image\nodes\plugins\VVVV.Nodes.OpenCV.dll" nodename="ContourPerimeter (OpenCV Split)" componentmode="Hidden" id="47">
+   <BOUNDS type="Node" left="5250" top="6120" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="21" srcpinname="Perimeter" dstnodeid="47" dstpinname="Input">
+   </LINK>
+   </PATCH>

--- a/girlpower/ImageAnalysis - Overview.v4p
+++ b/girlpower/ImageAnalysis - Overview.v4p
@@ -1,9 +1,9 @@
 <!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45debug31.3.dtd" >
-   <PATCH nodename="C:\Users\joreg\dev\repos\vvvv\public\vvvv45\packs\Image\girlpower\ImageAnalysis - Overview.v4p" systemname="ImageAnalysis - Overview" filename="C:\Users\joreg\dev\repos\vvvv\public\vvvv45\packs\Image\girlpower\ImageAnalysis - Overview.v4p">
+   <PATCH nodename="C:\Users\joreg\dev\repos\VVVV.Packs.Image\girlpower\ImageAnalysis - Overview.v4p" systemname="ImageAnalysis - Overview" filename="C:\Users\joreg\dev\repos\vvvv\public\vvvv45\packs\Image\girlpower\ImageAnalysis - Overview.v4p">
    <BOUNDS type="Window" left="9555" top="4875" width="11520" height="7410">
    </BOUNDS>
    <NODE systemname="Renderer (OpenCV)" filename="%VVVV%\packs\Image\nodes\plugins\VVVV.Nodes.OpenCV.dll" nodename="Renderer (OpenCV)" componentmode="InAWindow" id="35">
-   <BOUNDS type="Node" left="5205" top="1935" width="100" height="100">
+   <BOUNDS type="Node" left="4110" top="1605" width="100" height="100">
    </BOUNDS>
    <BOUNDS type="Window" left="150" top="1170" width="6240" height="5010">
    </BOUNDS>
@@ -11,13 +11,13 @@
    </PIN>
    <PIN pinname="Slice" slicecount="1" values="0">
    </PIN>
-   <BOUNDS type="Box" left="5205" top="1935">
+   <BOUNDS type="Box" left="4110" top="1605">
    </BOUNDS>
    <PIN pinname="Descriptive Name" slicecount="1" values="||">
    </PIN>
    </NODE>
    <NODE systemname="Pipet (OpenCV)" filename="%VVVV%\packs\Image\nodes\plugins\VVVV.Nodes.OpenCV.dll" nodename="Pipet (OpenCV)" componentmode="Hidden" id="0">
-   <BOUNDS type="Node" left="2520" top="3825" width="100" height="100">
+   <BOUNDS type="Node" left="3930" top="3750" width="100" height="100">
    </BOUNDS>
    <PIN pinname="Input" visible="1" slicecount="1" values="||">
    </PIN>
@@ -27,21 +27,21 @@
    </PIN>
    <PIN pinname="Input 2">
    </PIN>
-   <BOUNDS type="Box" left="2520" top="3825">
+   <BOUNDS type="Box" left="3930" top="3750">
    </BOUNDS>
    </NODE>
    <NODE systemname="Framerate (OpenCV)" filename="%VVVV%\packs\Image\nodes\plugins\VVVV.Nodes.OpenCV.dll" nodename="Framerate (OpenCV)" componentmode="Hidden" id="20">
-   <BOUNDS type="Node" left="4020" top="3840" width="100" height="100">
+   <BOUNDS type="Node" left="1485" top="3750" width="100" height="100">
    </BOUNDS>
    <PIN pinname="Input" visible="1" slicecount="1" values="||">
    </PIN>
    <PIN pinname="Output" visible="1">
    </PIN>
-   <BOUNDS type="Box" left="4020" top="3840">
+   <BOUNDS type="Box" left="1485" top="3750">
    </BOUNDS>
    </NODE>
    <NODE systemname="Contour (OpenCV)" filename="%VVVV%\packs\Image\nodes\plugins\VVVV.Nodes.OpenCV.dll" nodename="Contour (OpenCV)" componentmode="Hidden" id="21">
-   <BOUNDS type="Node" left="5025" top="3825" width="100" height="100">
+   <BOUNDS type="Node" left="5580" top="3750" width="100" height="100">
    </BOUNDS>
    <PIN pinname="Input" visible="1" slicecount="1" values="||">
    </PIN>
@@ -51,7 +51,7 @@
    </PIN>
    <PIN pinname="Pass original">
    </PIN>
-   <BOUNDS type="Box" left="5025" top="3825">
+   <BOUNDS type="Box" left="5580" top="3750">
    </BOUNDS>
    <PIN pinname="Perimeter" visible="1">
    </PIN>
@@ -75,7 +75,7 @@
    <LINK srcnodeid="17" srcpinname="Output" dstnodeid="35" dstpinname="Input">
    </LINK>
    <NODE systemname="Change (OpenCV)" nodename="Change (OpenCV)" componentmode="Hidden" id="19" filename="%VVVV%\packs\Image\nodes\plugins\VVVV.Nodes.OpenCV.dll">
-   <BOUNDS type="Node" left="3150" top="3825" width="100" height="100">
+   <BOUNDS type="Node" left="615" top="3750" width="100" height="100">
    </BOUNDS>
    <PIN pinname="Input" visible="1" slicecount="1" values="||">
    </PIN>
@@ -83,15 +83,15 @@
    </PIN>
    <PIN pinname="Input 2">
    </PIN>
-   <BOUNDS type="Box" left="3150" top="3825">
+   <BOUNDS type="Box" left="615" top="3750">
    </BOUNDS>
    </NODE>
    <LINK srcnodeid="17" srcpinname="Output" dstnodeid="19" dstpinname="Input">
    </LINK>
    <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="37" systemname="IOBox (Value Advanced)">
-   <BOUNDS type="Box" left="3000" top="3105" width="795" height="480">
+   <BOUNDS type="Box" left="4335" top="3120" width="795" height="480">
    </BOUNDS>
-   <BOUNDS type="Node" left="3000" top="3105" width="0" height="0">
+   <BOUNDS type="Node" left="4335" top="3120" width="0" height="0">
    </BOUNDS>
    <PIN pinname="Y Input Value" slicecount="2" values="0.5,0.5">
    </PIN>
@@ -107,9 +107,9 @@
    <LINK srcnodeid="37" srcpinname="Y Output Value" dstnodeid="0" dstpinname="Position px">
    </LINK>
    <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="39" systemname="IOBox (Value Advanced)">
-   <BOUNDS type="Box" left="3075" top="4845" width="795" height="240">
+   <BOUNDS type="Box" left="615" top="4275" width="795" height="240">
    </BOUNDS>
-   <BOUNDS type="Node" left="3075" top="4845" width="0" height="0">
+   <BOUNDS type="Node" left="615" top="4275" width="0" height="0">
    </BOUNDS>
    <PIN pinname="Units" slicecount="1" values="||">
    </PIN>
@@ -121,9 +121,9 @@
    <LINK srcnodeid="19" srcpinname="Output frames" dstnodeid="39" dstpinname="Y Input Value">
    </LINK>
    <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="40" systemname="IOBox (Value Advanced)">
-   <BOUNDS type="Box" left="1230" top="4785" width="795" height="720">
+   <BOUNDS type="Box" left="3930" top="4410" width="645" height="705">
    </BOUNDS>
-   <BOUNDS type="Node" left="1230" top="4785" width="0" height="0">
+   <BOUNDS type="Node" left="3930" top="4410" width="0" height="0">
    </BOUNDS>
    <PIN pinname="Units" slicecount="1" values="||">
    </PIN>
@@ -141,9 +141,9 @@
    <LINK srcnodeid="0" srcpinname="Output" dstnodeid="40" dstpinname="Y Input Value">
    </LINK>
    <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="41" systemname="IOBox (Value Advanced)">
-   <BOUNDS type="Box" left="4245" top="4845" width="795" height="240">
+   <BOUNDS type="Box" left="1485" top="4275" width="795" height="240">
    </BOUNDS>
-   <BOUNDS type="Node" left="4245" top="4845" width="0" height="0">
+   <BOUNDS type="Node" left="1485" top="4275" width="0" height="0">
    </BOUNDS>
    <PIN pinname="Units" slicecount="1" values="||">
    </PIN>
@@ -153,17 +153,19 @@
    <LINK srcnodeid="20" srcpinname="Framerate fps" dstnodeid="41" dstpinname="Y Input Value">
    </LINK>
    <NODE systemname="AvgSdv (OpenCV Mean)" filename="%VVVV%\packs\Image\nodes\plugins\VVVV.Nodes.OpenCV.dll" nodename="AvgSdv (OpenCV Mean)" componentmode="Hidden" id="42">
-   <BOUNDS type="Node" left="6495" top="3825" width="100" height="100">
+   <BOUNDS type="Node" left="7050" top="3750" width="100" height="100">
    </BOUNDS>
    <PIN pinname="Input" visible="1">
    </PIN>
+   <BOUNDS type="Box" left="7050" top="3750">
+   </BOUNDS>
    </NODE>
    <LINK srcnodeid="17" srcpinname="Output" dstnodeid="42" dstpinname="Input">
    </LINK>
    <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="43" systemname="IOBox (Value Advanced)">
-   <BOUNDS type="Box" left="6495" top="4635" width="795" height="720">
+   <BOUNDS type="Box" left="7050" top="4560" width="795" height="720">
    </BOUNDS>
-   <BOUNDS type="Node" left="6495" top="4635" width="0" height="0">
+   <BOUNDS type="Node" left="7050" top="4560" width="0" height="0">
    </BOUNDS>
    <PIN pinname="Units" slicecount="1" values="||">
    </PIN>
@@ -181,17 +183,19 @@
    <LINK srcnodeid="42" srcpinname="Average" dstnodeid="43" dstpinname="Y Input Value">
    </LINK>
    <NODE systemname="ObjectTracking (OpenCV)" filename="%VVVV%\packs\Image\nodes\plugins\VVVV.Nodes.OpenCV.dll" nodename="ObjectTracking (OpenCV)" componentmode="Hidden" id="44">
-   <BOUNDS type="Node" left="7860" top="3810" width="100" height="100">
+   <BOUNDS type="Node" left="8415" top="3750" width="100" height="100">
    </BOUNDS>
    <PIN pinname="Input" visible="1">
    </PIN>
+   <BOUNDS type="Box" left="8415" top="3750">
+   </BOUNDS>
    </NODE>
    <LINK srcnodeid="17" srcpinname="Output" dstnodeid="44" dstpinname="Input">
    </LINK>
    <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="45" systemname="IOBox (Value Advanced)">
-   <BOUNDS type="Box" left="7890" top="4710" width="795" height="480">
+   <BOUNDS type="Box" left="8415" top="4560" width="795" height="480">
    </BOUNDS>
-   <BOUNDS type="Node" left="7890" top="4710" width="0" height="0">
+   <BOUNDS type="Node" left="8415" top="4560" width="0" height="0">
    </BOUNDS>
    <PIN pinname="Units" slicecount="1" values="||">
    </PIN>
@@ -207,7 +211,7 @@
    <LINK srcnodeid="44" srcpinname="PositionXY" dstnodeid="45" dstpinname="Y Input Value">
    </LINK>
    <NODE systemname="ContourDelauney (OpenCV)" filename="%VVVV%\packs\Image\nodes\plugins\VVVV.Nodes.OpenCV.dll" nodename="ContourDelauney (OpenCV)" componentmode="Hidden" id="46">
-   <BOUNDS type="Node" left="5535" top="5670" width="100" height="100">
+   <BOUNDS type="Node" left="6090" top="5595" width="100" height="100">
    </BOUNDS>
    <PIN pinname="Input" visible="1">
    </PIN>
@@ -215,11 +219,27 @@
    <LINK srcnodeid="21" srcpinname="Perimeter" dstnodeid="46" dstpinname="Input">
    </LINK>
    <NODE systemname="ContourPerimeter (OpenCV Split)" filename="%VVVV%\packs\Image\nodes\plugins\VVVV.Nodes.OpenCV.dll" nodename="ContourPerimeter (OpenCV Split)" componentmode="Hidden" id="47">
-   <BOUNDS type="Node" left="5250" top="6120" width="100" height="100">
+   <BOUNDS type="Node" left="5805" top="6045" width="100" height="100">
    </BOUNDS>
    <PIN pinname="Input" visible="1">
    </PIN>
    </NODE>
    <LINK srcnodeid="21" srcpinname="Perimeter" dstnodeid="47" dstpinname="Input">
    </LINK>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="48" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="645" top="555" width="1080" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="645" top="555" width="1920" height="690">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="|Extracting data from images|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   <PIN pinname="Size" slicecount="1" values="12">
+   </PIN>
+   </NODE>
    </PATCH>

--- a/girlpower/ImageFilter - Overview.v4p
+++ b/girlpower/ImageFilter - Overview.v4p
@@ -1,0 +1,549 @@
+<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45debug31.3.dtd" >
+   <PATCH nodename="C:\Users\joreg\dev\repos\vvvv\public\vvvv45\packs\Image\girlpower\ImageFilter - Overview.v4p" systemname="ImageFilter - Overview" filename="C:\Users\joreg\dev\repos\vvvv\public\vvvv45\packs\Image\girlpower\ImageFilter - Overview.v4p">
+   <BOUNDS type="Window" left="195" top="6225" width="21465" height="7845">
+   </BOUNDS>
+   <NODE systemname="&lt; (OpenCV Filter, Scalar)" filename="%VVVV%\packs\Image\nodes\plugins\VVVV.Nodes.OpenCV.dll" nodename="&lt; (OpenCV Filter, Scalar)" componentmode="Hidden" id="0">
+   <BOUNDS type="Node" left="780" top="4320" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <PIN pinname="Pass original" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Input 2" slicecount="1" values="0.5">
+   </PIN>
+   <BOUNDS type="Box" left="780" top="4320">
+   </BOUNDS>
+   </NODE>
+   <NODE systemname="Canny (OpenCV)" filename="%VVVV%\packs\Image\nodes\plugins\VVVV.Nodes.OpenCV.dll" nodename="Canny (OpenCV)" componentmode="Hidden" id="1">
+   <BOUNDS type="Node" left="4905" top="4335" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <PIN pinname="Threshold min" slicecount="1" values="20">
+   </PIN>
+   <PIN pinname="Threshold max" slicecount="1" values="40">
+   </PIN>
+   <PIN pinname="Window size" slicecount="1" values="3">
+   </PIN>
+   <BOUNDS type="Box" left="4905" top="4335">
+   </BOUNDS>
+   </NODE>
+   <NODE systemname="Grayscale (OpenCV)" filename="%VVVV%\packs\Image\nodes\plugins\VVVV.Nodes.OpenCV.dll" nodename="Grayscale (OpenCV)" componentmode="Hidden" id="4">
+   <BOUNDS type="Node" left="9255" top="4335" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <BOUNDS type="Box" left="9255" top="4335">
+   </BOUNDS>
+   </NODE>
+   <NODE systemname="Renderer (OpenCV)" filename="%VVVV%\packs\Image\nodes\plugins\VVVV.Nodes.OpenCV.dll" nodename="Renderer (OpenCV)" componentmode="InAWindow" id="18">
+   <BOUNDS type="Node" left="6390" top="5730" width="100" height="100">
+   </BOUNDS>
+   <BOUNDS type="Window" left="6405" top="1170" width="6240" height="5010">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Slice" slicecount="1" values="0">
+   </PIN>
+   <BOUNDS type="Box" left="6390" top="5730">
+   </BOUNDS>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Pixel">
+   </PIN>
+   </NODE>
+   <NODE systemname="ImageLoad (OpenCV FreeImage)" filename="%VVVV%\packs\Image\nodes\plugins\VVVV.Nodes.FreeImage.dll" nodename="ImageLoad (OpenCV FreeImage)" componentmode="Hidden" id="17">
+   <BOUNDS type="Node" left="3930" top="885" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <PIN pinname="Filename" slicecount="1" values="..\..\..\lib\assets\images\earth_512x512.jpg">
+   </PIN>
+   <PIN pinname="Enabled" slicecount="1" values="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="17" srcpinname="Output" dstnodeid="4" dstpinname="Input">
+   </LINK>
+   <LINK srcnodeid="17" srcpinname="Output" dstnodeid="1" dstpinname="Input">
+   </LINK>
+   <LINK srcnodeid="17" srcpinname="Output" dstnodeid="0" dstpinname="Input">
+   </LINK>
+   <NODE systemname="&gt; (OpenCV Filter, Scalar)" nodename="&gt; (OpenCV Filter, Scalar)" componentmode="Hidden" id="19" filename="%VVVV%\packs\Image\nodes\plugins\VVVV.Nodes.OpenCV.dll">
+   <BOUNDS type="Node" left="1410" top="4320" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <PIN pinname="Input 2" slicecount="1" values="0.5">
+   </PIN>
+   <BOUNDS type="Box" left="1410" top="4320">
+   </BOUNDS>
+   </NODE>
+   <LINK srcnodeid="17" srcpinname="Output" dstnodeid="19" dstpinname="Input">
+   </LINK>
+   <NODE systemname="Not (OpenCV Filter)" filename="%VVVV%\packs\Image\nodes\plugins\VVVV.Nodes.OpenCV.dll" nodename="Not (OpenCV Filter)" componentmode="Hidden" id="20">
+   <BOUNDS type="Node" left="2025" top="4320" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <BOUNDS type="Box" left="2025" top="4320">
+   </BOUNDS>
+   </NODE>
+   <LINK srcnodeid="17" srcpinname="Output" dstnodeid="20" dstpinname="Input">
+   </LINK>
+   <NODE systemname="= (OpenCV Filter, Scalar)" filename="%VVVV%\packs\Image\nodes\plugins\VVVV.Nodes.OpenCV.dll" nodename="= (OpenCV Filter, Scalar)" componentmode="Hidden" id="21">
+   <BOUNDS type="Node" left="2595" top="4320" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <PIN pinname="Input 2" slicecount="1" values="0.5">
+   </PIN>
+   <PIN pinname="Pass original" slicecount="1" values="0">
+   </PIN>
+   <BOUNDS type="Box" left="2595" top="4320">
+   </BOUNDS>
+   </NODE>
+   <LINK srcnodeid="17" srcpinname="Output" dstnodeid="21" dstpinname="Input">
+   </LINK>
+   <NODE systemname="Erode (OpenCV)" filename="%VVVV%\packs\Image\nodes\plugins\VVVV.Nodes.OpenCV.dll" nodename="Erode (OpenCV)" componentmode="Hidden" id="22">
+   <BOUNDS type="Node" left="7530" top="4335" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <PIN pinname="Iterations" slicecount="1" values="1">
+   </PIN>
+   <BOUNDS type="Box" left="7530" top="4335">
+   </BOUNDS>
+   </NODE>
+   <LINK srcnodeid="17" srcpinname="Output" dstnodeid="22" dstpinname="Input">
+   </LINK>
+   <NODE systemname="Sobel (OpenCV)" filename="%VVVV%\packs\Image\nodes\plugins\VVVV.Nodes.OpenCV.dll" nodename="Sobel (OpenCV)" componentmode="Hidden" id="24">
+   <BOUNDS type="Node" left="10200" top="4335" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <BOUNDS type="Box" left="10200" top="4335">
+   </BOUNDS>
+   </NODE>
+   <LINK srcnodeid="17" srcpinname="Output" dstnodeid="24" dstpinname="Input">
+   </LINK>
+   <NODE systemname="Dilate (OpenCV)" filename="%VVVV%\packs\Image\nodes\plugins\VVVV.Nodes.OpenCV.dll" nodename="Dilate (OpenCV)" componentmode="Hidden" id="25">
+   <BOUNDS type="Node" left="6810" top="4335" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <BOUNDS type="Box" left="6810" top="4335">
+   </BOUNDS>
+   <PIN pinname="Iterations" slicecount="1" values="1">
+   </PIN>
+   </NODE>
+   <NODE systemname="GaussianBlur (OpenCV)" filename="%VVVV%\packs\Image\nodes\plugins\VVVV.Nodes.OpenCV.dll" nodename="GaussianBlur (OpenCV)" componentmode="Hidden" id="26">
+   <BOUNDS type="Node" left="8220" top="4335" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <BOUNDS type="Box" left="8220" top="4335">
+   </BOUNDS>
+   <PIN pinname="Width" slicecount="1" values="15">
+   </PIN>
+   </NODE>
+   <NODE systemname="ConvertScale (OpenCV)" filename="%VVVV%\packs\Image\nodes\plugins\VVVV.Nodes.OpenCV.dll" nodename="ConvertScale (OpenCV)" componentmode="Hidden" id="27">
+   <BOUNDS type="Node" left="5655" top="4335" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <BOUNDS type="Box" left="5655" top="4335">
+   </BOUNDS>
+   <PIN pinname="Scale" slicecount="1" visible="1" values="0.73">
+   </PIN>
+   <PIN pinname="Offset" slicecount="1" values="0">
+   </PIN>
+   </NODE>
+   <NODE systemname="FrameDifference (OpenCV)" filename="%VVVV%\packs\Image\nodes\plugins\VVVV.Nodes.OpenCV.dll" nodename="FrameDifference (OpenCV)" componentmode="Hidden" id="29">
+   <BOUNDS type="Node" left="13200" top="4335" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <BOUNDS type="Box" left="13200" top="4335">
+   </BOUNDS>
+   <PIN pinname="Threshold Enabled" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Difference Mode" slicecount="1" values="AbsoluteDifference">
+   </PIN>
+   <PIN pinname="Threshold" slicecount="1" values="0">
+   </PIN>
+   </NODE>
+   <NODE systemname="Average (OpenCV Temporal)" filename="%VVVV%\packs\Image\nodes\plugins\VVVV.Nodes.OpenCV.dll" nodename="Average (OpenCV Temporal)" componentmode="Hidden" id="30">
+   <BOUNDS type="Node" left="12300" top="4335" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <BOUNDS type="Box" left="12300" top="4335">
+   </BOUNDS>
+   <PIN pinname="Frames" slicecount="1" values="7">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="17" srcpinname="Output" dstnodeid="27" dstpinname="Input">
+   </LINK>
+   <LINK srcnodeid="17" srcpinname="Output" dstnodeid="25" dstpinname="Input">
+   </LINK>
+   <LINK srcnodeid="17" srcpinname="Output" dstnodeid="26" dstpinname="Input">
+   </LINK>
+   <NODE systemname="Switch (Node Input)" nodename="Switch (Node Input)" componentmode="Hidden" id="31">
+   <BOUNDS type="Node" left="6375" top="5115" width="2265" height="270">
+   </BOUNDS>
+   <PIN pinname="Input 1" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <PIN pinname="Input 2" visible="1">
+   </PIN>
+   <PIN pinname="Input Count" slicecount="1" values="7">
+   </PIN>
+   <PIN pinname="Input 3" visible="1">
+   </PIN>
+   <PIN pinname="Input 4" visible="1">
+   </PIN>
+   <PIN pinname="Input 5" visible="1">
+   </PIN>
+   <PIN pinname="Input 6" visible="1">
+   </PIN>
+   <PIN pinname="Input 7" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="1" srcpinname="Output" dstnodeid="31" dstpinname="Input 1">
+   </LINK>
+   <LINK srcnodeid="31" srcpinname="Output" dstnodeid="18" dstpinname="Input">
+   </LINK>
+   <LINK srcnodeid="27" srcpinname="Output" dstnodeid="31" dstpinname="Input 2">
+   </LINK>
+   <LINK srcnodeid="25" srcpinname="Output" dstnodeid="31" dstpinname="Input 3">
+   </LINK>
+   <LINK srcnodeid="22" srcpinname="Output" dstnodeid="31" dstpinname="Input 4">
+   </LINK>
+   <LINK srcnodeid="26" srcpinname="Output" dstnodeid="31" dstpinname="Input 5">
+   </LINK>
+   <LINK srcnodeid="4" srcpinname="Output" dstnodeid="31" dstpinname="Input 6">
+   </LINK>
+   <LINK srcnodeid="24" srcpinname="Output" dstnodeid="31" dstpinname="Input 7">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="32" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="4305" top="4920" width="465" height="240">
+   </BOUNDS>
+   <BOUNDS type="Node" left="4305" top="4920" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Integer">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="32" srcpinname="Y Output Value" dstnodeid="31" dstpinname="Switch">
+   </LINK>
+   <NODE systemname="Renderer (OpenCV)" filename="%VVVV%\packs\Image\nodes\plugins\VVVV.Nodes.OpenCV.dll" nodename="Renderer (OpenCV)" componentmode="InAWindow" id="35">
+   <BOUNDS type="Node" left="810" top="5730" width="100" height="100">
+   </BOUNDS>
+   <BOUNDS type="Window" left="150" top="1170" width="6240" height="5010">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Slice" slicecount="1" values="0">
+   </PIN>
+   <BOUNDS type="Box" left="810" top="5730">
+   </BOUNDS>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Scalar">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="33" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="165" top="4890" width="465" height="240">
+   </BOUNDS>
+   <BOUNDS type="Node" left="165" top="4890" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Integer">
+   </PIN>
+   </NODE>
+   <NODE systemname="VideoIn (OpenCV)" filename="%VVVV%\packs\Image\nodes\plugins\VVVV.Nodes.OpenCV.dll" nodename="VideoIn (OpenCV)" componentmode="Hidden" id="36">
+   <BOUNDS type="Node" left="12675" top="1470" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <PIN pinname="Enabled" slicecount="1" values="1">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="37" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="13245" top="705" width="480" height="480">
+   </BOUNDS>
+   <BOUNDS type="Node" left="13245" top="705" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Boolean">
+   </PIN>
+   <PIN pinname="Behavior" slicecount="1" values="Toggle">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="37" srcpinname="Y Output Value" dstnodeid="36" dstpinname="Enabled">
+   </LINK>
+   <NODE systemname="ListDevices (OpenCV DirectShow)" filename="%VVVV%\packs\Image\nodes\plugins\VVVV.Nodes.OpenCV.VideoInput.dll" nodename="ListDevices (OpenCV DirectShow)" componentmode="Hidden" id="38">
+   <BOUNDS type="Node" left="10275" top="450" width="100" height="100">
+   </BOUNDS>
+   </NODE>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="39" systemname="IOBox (String)">
+   <BOUNDS type="Box" left="10290" top="1050" width="1845" height="480">
+   </BOUNDS>
+   <BOUNDS type="Node" left="10290" top="1050" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Default" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="File Mask" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Maximum Characters" slicecount="1" values="-1">
+   </PIN>
+   <PIN pinname="Show SliceIndex" slicecount="1" values="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="38" srcpinname="Device name" dstnodeid="39" dstpinname="Input String">
+   </LINK>
+   <NODE systemname="Renderer (OpenCV)" filename="%VVVV%\packs\Image\nodes\plugins\VVVV.Nodes.OpenCV.dll" nodename="Renderer (OpenCV)" componentmode="InAWindow" id="42">
+   <BOUNDS type="Node" left="12360" top="5730" width="100" height="100">
+   </BOUNDS>
+   <BOUNDS type="Window" left="12705" top="1155" width="6240" height="5010">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Slice" slicecount="1" values="0">
+   </PIN>
+   <BOUNDS type="Box" left="12360" top="5730">
+   </BOUNDS>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Temporal">
+   </PIN>
+   </NODE>
+   <NODE systemname="Switch (Node Input)" nodename="Switch (Node Input)" componentmode="Hidden" id="41">
+   <BOUNDS type="Node" left="12360" top="5115" width="6780" height="270">
+   </BOUNDS>
+   <PIN pinname="Input 1" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <PIN pinname="Input 2" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Input Count" slicecount="1" values="6">
+   </PIN>
+   <PIN pinname="Input 3" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Input 4" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Input 5" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Input 6" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Input 7" visible="1" slicecount="1" values="||">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="40" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="11730" top="4890" width="465" height="240">
+   </BOUNDS>
+   <BOUNDS type="Node" left="11730" top="4890" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Integer">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="40" srcpinname="Y Output Value" dstnodeid="41" dstpinname="Switch">
+   </LINK>
+   <LINK srcnodeid="30" srcpinname="Output" dstnodeid="41" dstpinname="Input 1">
+   </LINK>
+   <LINK srcnodeid="29" srcpinname="Output" dstnodeid="41" dstpinname="Input 2">
+   </LINK>
+   <NODE systemname="AdaptiveThreshold (OpenCV)" filename="%VVVV%\packs\Image\nodes\plugins\VVVV.Nodes.OpenCV.dll" nodename="AdaptiveThreshold (OpenCV)" componentmode="Hidden" id="43">
+   <BOUNDS type="Node" left="16275" top="4335" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <BOUNDS type="Box" left="16275" top="4335">
+   </BOUNDS>
+   </NODE>
+   <NODE systemname="OpticalFlowHS (OpenCV)" filename="%VVVV%\packs\Image\nodes\plugins\VVVV.Nodes.OpenCV.dll" nodename="OpticalFlowHS (OpenCV)" componentmode="Hidden" id="51">
+   <BOUNDS type="Node" left="17940" top="4335" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <PIN pinname="Use Previous Velocity" slicecount="1" values="0">
+   </PIN>
+   <BOUNDS type="Box" left="17940" top="4335">
+   </BOUNDS>
+   </NODE>
+   <LINK srcnodeid="36" srcpinname="Output" dstnodeid="51" dstpinname="Input">
+   </LINK>
+   <LINK srcnodeid="36" srcpinname="Output" dstnodeid="43" dstpinname="Input">
+   </LINK>
+   <LINK srcnodeid="41" srcpinname="Output" dstnodeid="42" dstpinname="Input">
+   </LINK>
+   <NODE systemname="OpticalFlowLK (OpenCV)" filename="%VVVV%\packs\Image\nodes\plugins\VVVV.Nodes.OpenCV.dll" nodename="OpticalFlowLK (OpenCV)" componentmode="Hidden" id="52">
+   <BOUNDS type="Node" left="19170" top="4335" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <BOUNDS type="Box" left="19170" top="4335">
+   </BOUNDS>
+   </NODE>
+   <LINK srcnodeid="36" srcpinname="Output" dstnodeid="52" dstpinname="Input">
+   </LINK>
+   <NODE systemname="BackgroundSubtract (OpenCV)" filename="%VVVV%\packs\Image\nodes\plugins\VVVV.Nodes.OpenCV.dll" nodename="BackgroundSubtract (OpenCV)" componentmode="Hidden" id="53">
+   <BOUNDS type="Node" left="14550" top="4335" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <BOUNDS type="Box" left="14550" top="4335">
+   </BOUNDS>
+   </NODE>
+   <LINK srcnodeid="36" srcpinname="Output" dstnodeid="53" dstpinname="Input">
+   </LINK>
+   <LINK srcnodeid="53" srcpinname="Output" dstnodeid="41" dstpinname="Input 3">
+   </LINK>
+   <LINK srcnodeid="43" srcpinname="Output" dstnodeid="41" dstpinname="Input 4">
+   </LINK>
+   <LINK srcnodeid="51" srcpinname="Output" dstnodeid="41" dstpinname="Input 5">
+   </LINK>
+   <LINK srcnodeid="52" srcpinname="Output" dstnodeid="41" dstpinname="Input 6">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="54" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="14880" top="3585" width="480" height="480">
+   </BOUNDS>
+   <BOUNDS type="Node" left="14880" top="3585" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Boolean">
+   </PIN>
+   <PIN pinname="Behavior" slicecount="1" values="Toggle">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="54" srcpinname="Y Output Value" dstnodeid="53" dstpinname="Set">
+   </LINK>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="55" systemname="IOBox (String)">
+   <BOUNDS type="Box" left="3945" top="420" width="1980" height="270">
+   </BOUNDS>
+   <BOUNDS type="Node" left="3945" top="420" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Input String" slicecount="1" values="..\..\..\lib\assets\images\earth_512x512.jpg">
+   </PIN>
+   <PIN pinname="Default" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="File Mask" slicecount="1" values="|All Files (*.*)||*.*|">
+   </PIN>
+   <PIN pinname="Maximum Characters" slicecount="1" values="-1">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="Filename">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="55" srcpinname="Output String" dstnodeid="17" dstpinname="Filename">
+   </LINK>
+   <LINK srcnodeid="36" srcpinname="Output" dstnodeid="29" dstpinname="Input">
+   </LINK>
+   <LINK srcnodeid="36" srcpinname="Output" dstnodeid="30" dstpinname="Input">
+   </LINK>
+   <NODE systemname="Random (Value)" nodename="Random (Value)" componentmode="Hidden" id="58">
+   <BOUNDS type="Node" left="5910" top="3750" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="58" srcpinname="Output" dstnodeid="27" dstpinname="Scale">
+   </LINK>
+   <NODE systemname="WithinRange (OpenCV Filter, Scalar)" filename="%VVVV%\packs\Image\nodes\plugins\VVVV.Nodes.OpenCV.dll" nodename="WithinRange (OpenCV Filter, Scalar)" componentmode="Hidden" id="59">
+   <BOUNDS type="Node" left="3195" top="4320" width="100" height="100">
+   </BOUNDS>
+   <BOUNDS type="Box" left="3195" top="4320">
+   </BOUNDS>
+   </NODE>
+   <LINK srcnodeid="17" srcpinname="Output" dstnodeid="59" dstpinname="Input">
+   </LINK>
+   <NODE id="34" systemname="Switch (Node Input)" nodename="Switch (Node Input)" componentmode="Hidden">
+   <PIN pinname="Input 5" visible="1">
+   </PIN>
+   <BOUNDS type="Node" left="810" top="5115" width="2265" height="270">
+   </BOUNDS>
+   <PIN pinname="Input 1" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <PIN pinname="Input 2" visible="1">
+   </PIN>
+   <PIN pinname="Input Count" slicecount="1" values="5">
+   </PIN>
+   <PIN pinname="Input 3" visible="1">
+   </PIN>
+   <PIN pinname="Input 4" visible="1">
+   </PIN>
+   <PIN pinname="Input 6" visible="1">
+   </PIN>
+   <PIN pinname="Input 7" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="59" srcpinname="Output" dstnodeid="34" dstpinname="Input 5">
+   </LINK>
+   <LINK srcnodeid="21" srcpinname="Output" dstnodeid="34" dstpinname="Input 4">
+   </LINK>
+   <LINK srcnodeid="20" srcpinname="Output" dstnodeid="34" dstpinname="Input 3">
+   </LINK>
+   <LINK srcnodeid="19" srcpinname="Output" dstnodeid="34" dstpinname="Input 2">
+   </LINK>
+   <LINK srcnodeid="0" srcpinname="Output" dstnodeid="34" dstpinname="Input 1">
+   </LINK>
+   <LINK srcnodeid="33" srcpinname="Y Output Value" dstnodeid="34" dstpinname="Switch">
+   </LINK>
+   <LINK srcnodeid="34" srcpinname="Output" dstnodeid="35" dstpinname="Input">
+   </LINK>
+   </PATCH>

--- a/girlpower/ImageFilter - Overview.v4p
+++ b/girlpower/ImageFilter - Overview.v4p
@@ -1,5 +1,5 @@
 <!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45debug31.3.dtd" >
-   <PATCH nodename="C:\Users\joreg\dev\repos\vvvv\public\vvvv45\packs\Image\girlpower\ImageFilter - Overview.v4p" systemname="ImageFilter - Overview" filename="C:\Users\joreg\dev\repos\vvvv\public\vvvv45\packs\Image\girlpower\ImageFilter - Overview.v4p">
+   <PATCH nodename="C:\Users\joreg\dev\repos\VVVV.Packs.Image\girlpower\ImageFilter - Overview.v4p" systemname="ImageFilter - Overview" filename="C:\Users\joreg\dev\repos\vvvv\public\vvvv45\packs\Image\girlpower\ImageFilter - Overview.v4p">
    <BOUNDS type="Window" left="195" top="6225" width="21465" height="7845">
    </BOUNDS>
    <NODE systemname="&lt; (OpenCV Filter, Scalar)" filename="%VVVV%\packs\Image\nodes\plugins\VVVV.Nodes.OpenCV.dll" nodename="&lt; (OpenCV Filter, Scalar)" componentmode="Hidden" id="0">
@@ -293,7 +293,7 @@
    </PIN>
    </NODE>
    <NODE systemname="VideoIn (OpenCV)" filename="%VVVV%\packs\Image\nodes\plugins\VVVV.Nodes.OpenCV.dll" nodename="VideoIn (OpenCV)" componentmode="Hidden" id="36">
-   <BOUNDS type="Node" left="12675" top="1470" width="100" height="100">
+   <BOUNDS type="Node" left="16245" top="1620" width="100" height="100">
    </BOUNDS>
    <PIN pinname="Output" visible="1">
    </PIN>
@@ -301,9 +301,9 @@
    </PIN>
    </NODE>
    <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="37" systemname="IOBox (Value Advanced)">
-   <BOUNDS type="Box" left="13245" top="705" width="480" height="480">
+   <BOUNDS type="Box" left="16815" top="855" width="480" height="480">
    </BOUNDS>
-   <BOUNDS type="Node" left="13245" top="705" width="0" height="0">
+   <BOUNDS type="Node" left="16815" top="855" width="0" height="0">
    </BOUNDS>
    <PIN pinname="Y Input Value" slicecount="1" values="1">
    </PIN>
@@ -319,13 +319,13 @@
    <LINK srcnodeid="37" srcpinname="Y Output Value" dstnodeid="36" dstpinname="Enabled">
    </LINK>
    <NODE systemname="ListDevices (OpenCV DirectShow)" filename="%VVVV%\packs\Image\nodes\plugins\VVVV.Nodes.OpenCV.VideoInput.dll" nodename="ListDevices (OpenCV DirectShow)" componentmode="Hidden" id="38">
-   <BOUNDS type="Node" left="10275" top="450" width="100" height="100">
+   <BOUNDS type="Node" left="13845" top="600" width="100" height="100">
    </BOUNDS>
    </NODE>
    <NODE nodename="IOBox (String)" componentmode="InABox" id="39" systemname="IOBox (String)">
-   <BOUNDS type="Box" left="10290" top="1050" width="1845" height="480">
+   <BOUNDS type="Box" left="13860" top="1200" width="1845" height="480">
    </BOUNDS>
-   <BOUNDS type="Node" left="10290" top="1050" width="0" height="0">
+   <BOUNDS type="Node" left="13860" top="1200" width="0" height="0">
    </BOUNDS>
    <PIN pinname="Default" slicecount="1" values="||">
    </PIN>
@@ -546,4 +546,36 @@
    </LINK>
    <LINK srcnodeid="34" srcpinname="Output" dstnodeid="35" dstpinname="Input">
    </LINK>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="60" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="675" top="795" width="1080" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="675" top="795" width="2115" height="375">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="|Static filters|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   <PIN pinname="Size" slicecount="1" values="12">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="61" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="11385" top="960" width="1080" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="11385" top="960" width="2115" height="375">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="|Temporal filters|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   <PIN pinname="Size" slicecount="1" values="12">
+   </PIN>
+   </NODE>
    </PATCH>


### PR DESCRIPTION
and while doing so it ocurred to me that quite a few problems appear with those simple cases:
- ImageLoad -> Renderer (OpenCV) shows image in wrong colors (tested with earth.jpg)
- the scalar filters don't seem to operate at all
- the normal filters seem to operate once but not on changing any of their inputs
- closing the patch results in an AV

note: all tested with currently availably binary (not latest github sources)
