### PR TITLE
obligatory fixes

### DIFF
--- a/src/nodes/plugins/Image/OpenCV/VVVV.CV.Nodes.csproj
+++ b/src/nodes/plugins/Image/OpenCV/VVVV.CV.Nodes.csproj
@@ -83,6 +83,7 @@
     </Reference>
     <Reference Include="VVVV.Nodes">
       <HintPath>..\..\..\..\..\..\..\lib\nodes\plugins\VVVV.Nodes.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="VVVV.Utils, Version=31.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\VVVV.Utils.31.3.2-develop-35\lib\net40\VVVV.Utils.dll</HintPath>

--- a/src/nodes/plugins/Image/OpenCV/src/Filters/GT,LT,EQ.cs
+++ b/src/nodes/plugins/Image/OpenCV/src/Filters/GT,LT,EQ.cs
@@ -76,7 +76,7 @@ namespace VVVV.CV.Nodes
 	#endregion
 
 	#region Instances
-	[FilterInstance(">", Help = "Greater than")]
+	[FilterInstance("GT", Help = "Greater than")]
 	public class GTInstance : CMPInstance
 	{
 		protected override void Compare(IntPtr CvMat)
@@ -85,7 +85,7 @@ namespace VVVV.CV.Nodes
 		}
 	}
 
-	[FilterInstance("<", Help = "Less than")]
+	[FilterInstance("LT", Help = "Less than")]
 	public class LTInstance : CMPInstance
 	{
 		protected override void Compare(IntPtr CvMat)
@@ -94,7 +94,7 @@ namespace VVVV.CV.Nodes
 		}
 	}
 
-	[FilterInstance("=", Help = "Equal to")]
+	[FilterInstance("EQ", Help = "Equal to")]
 	public class EQInstance : CMPInstance
 	{
 		protected override void Compare(IntPtr CvMat)


### PR DESCRIPTION
included vvvv.nodes was set to copylocal=true which duplicated quite some .dlls in the output
renamed GT, LT, EQ nodes: see their commit for details
