### PR TITLE
Edit SolvePnP to make it look more like CalibrateCamera, with wrapper patch, based on CalibrateProjector.Add new IntrinsicsJoin node

### DIFF
--- a/nodes/modules/Image/OpenCV/ProjectorExtrinsics (CV.Transform).v4p
+++ b/nodes/modules/Image/OpenCV/ProjectorExtrinsics (CV.Transform).v4p
@@ -1,0 +1,357 @@
+<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45beta31.2.dtd" >
+   <PATCH nodename="C:\Users\Benjamin\Documents\PROD\vvvv\vvvv-sdk\vvvv45\VVVV.Packs.Image\nodes\modules\Image\OpenCV\SolvePnP (CV.Transform).v4p" filename="C:\Users\Benjamin\Documents\PROD\vvvv\vvvv-sdk\vvvv45\VVVV.Packs.Image\lib\nodes\modules\Image\OpenCV\SolvePNP (OpenCV).v4p" systemname="SolvePNP (OpenCV)">
+   <BOUNDS height="8430" left="23760" top="-4185" type="Window" width="16965">
+   </BOUNDS>
+   <NODE componentmode="InABox" id="18" nodename="IOBox (Value Advanced)" systemname="IOBox (Value Advanced)">
+   <BOUNDS height="0" left="5160" top="525" type="Node" width="0">
+   </BOUNDS>
+   <BOUNDS height="480" left="5160" top="525" type="Box" width="795">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="2" values="1024,768">
+   </PIN>
+   <PIN encoded="0" pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Vector Size" slicecount="1" values="2">
+   </PIN>
+   <PIN pinname="Rows" slicecount="1" values="2">
+   </PIN>
+   <PIN pinname="Y Output Value" visible="1">
+   </PIN>
+   <PIN encoded="0" pinname="Descriptive Name" slicecount="1" values="Resolution">
+   </PIN>
+   </NODE>
+   <NODE componentmode="InABox" id="10" nodename="IOBox (Value Advanced)" systemname="IOBox (Value Advanced)">
+   <BOUNDS height="0" left="15945" top="615" type="Node" width="0">
+   </BOUNDS>
+   <BOUNDS height="480" left="15945" top="615" type="Box" width="480">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" values="0">
+   </PIN>
+   <PIN encoded="0" pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Boolean">
+   </PIN>
+   <PIN pinname="Behavior" slicecount="1" values="Bang">
+   </PIN>
+   <PIN encoded="0" pinname="Descriptive Name" slicecount="1" values="Solve">
+   </PIN>
+   <PIN pinname="X Input Value" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Y Output Value" visible="1">
+   </PIN>
+   </NODE>
+   <NODE componentmode="InABox" id="8" nodename="IOBox (String)" systemname="IOBox (String)">
+   <BOUNDS height="0" left="11730" top="5340" type="Node" width="0">
+   </BOUNDS>
+   <BOUNDS height="510" left="11730" top="5340" type="Box" width="3780">
+   </BOUNDS>
+   <PIN encoded="0" pinname="Default" slicecount="1" values="||">
+   </PIN>
+   <PIN encoded="0" pinname="File Mask" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Maximum Characters" slicecount="1" values="-1">
+   </PIN>
+   <PIN encoded="0" pinname="Descriptive Name" slicecount="1" values="Status">
+   </PIN>
+   <PIN pinname="Input String" visible="1" slicecount="1" values="||">
+   </PIN>
+   </NODE>
+   <NODE componentmode="InABox" id="3" nodename="IOBox (Node)" systemname="IOBox (Node)">
+   <BOUNDS height="100" left="2730" top="7080" type="Node" width="100">
+   </BOUNDS>
+   <BOUNDS height="240" left="2730" top="7080" type="Box" width="795">
+   </BOUNDS>
+   <PIN pinname="Output Node" visible="1">
+   </PIN>
+   <PIN pinname="Input Node" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN encoded="0" pinname="Descriptive Name" slicecount="1" values="|View Transform|">
+   </PIN>
+   </NODE>
+   <NODE componentmode="InABox" id="1" nodename="IOBox (Value Advanced)" systemname="IOBox (Value Advanced)">
+   <BOUNDS height="100" left="2640" top="690" type="Node" width="100">
+   </BOUNDS>
+   <BOUNDS height="720" left="2640" top="690" type="Box" width="825">
+   </BOUNDS>
+   <PIN pinname="Y Output Value" visible="1">
+   </PIN>
+   <PIN encoded="0" pinname="Descriptive Name" slicecount="1" values="|World XYZ|">
+   </PIN>
+   <PIN pinname="Y Input Value" slicecount="1" visible="1" values="0">
+   </PIN>
+   <PIN pinname="Rows" slicecount="1" values="3">
+   </PIN>
+   <PIN pinname="Vector Size" slicecount="1" values="3">
+   </PIN>
+   </NODE>
+   <NODE componentmode="InABox" id="0" nodename="IOBox (Value Advanced)" systemname="IOBox (Value Advanced)">
+   <BOUNDS height="100" left="1515" top="765" type="Node" width="100">
+   </BOUNDS>
+   <BOUNDS height="495" left="1515" top="765" type="Box" width="795">
+   </BOUNDS>
+   <PIN pinname="Y Output Value" visible="1">
+   </PIN>
+   <PIN encoded="0" pinname="Descriptive Name" slicecount="1" values="|Projection XY|">
+   </PIN>
+   <PIN pinname="Y Input Value" slicecount="1" visible="1" values="0">
+   </PIN>
+   <PIN pinname="Rows" slicecount="1" values="2">
+   </PIN>
+   <PIN pinname="Vector Size" slicecount="1" values="2">
+   </PIN>
+   </NODE>
+   <NODE componentmode="Hidden" id="24" nodename="Map (Value)" systemname="Map (Value)">
+   <BOUNDS height="100" left="1515" top="1995" type="Node" width="100">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <PIN pinname="Destination Maximum" visible="1">
+   </PIN>
+   <PIN pinname="Source Minimum" slicecount="1" values="-1">
+   </PIN>
+   <PIN pinname="Source Maximum" slicecount="1" values="1">
+   </PIN>
+   </NODE>
+   <LINK dstnodeid="24" dstpinname="Input" srcnodeid="0" srcpinname="Y Output Value">
+   </LINK>
+   <LINK dstnodeid="24" dstpinname="Destination Maximum" linkstyle="VHV" srcnodeid="18" srcpinname="Y Output Value">
+   <LINKPOINT x="5400" y="1398">
+   </LINKPOINT>
+   <LINKPOINT x="2010" y="1573">
+   </LINKPOINT>
+   </LINK>
+   <NODE componentmode="Hidden" hiddenwhenlocked="1" id="26" nodename="GetMatrix (Transform)" systemname="GetMatrix (Transform)">
+   <BOUNDS height="100" left="810" top="5730" type="Node" width="100">
+   </BOUNDS>
+   <PIN pinname="Transform" visible="1">
+   </PIN>
+   <PIN pinname="Matrix Out" visible="1">
+   </PIN>
+   </NODE>
+   <NODE componentmode="InABox" hiddenwhenlocked="0" id="27" nodename="IOBox (Value Advanced)" systemname="IOBox (Value Advanced)">
+   <BOUNDS height="0" left="810" top="6345" type="Node" width="0">
+   </BOUNDS>
+   <BOUNDS height="930" left="810" top="6345" type="Box" width="1905">
+   </BOUNDS>
+   <PIN encoded="0" pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Vector Size" slicecount="1" values="16">
+   </PIN>
+   <PIN pinname="Columns" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Rows" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Y Input Value">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="1">
+   </PIN>
+   </NODE>
+   <LINK dstnodeid="27" dstpinname="Y Input Value" hiddenwhenlocked="1" srcnodeid="26" srcpinname="Matrix Out">
+   </LINK>
+   <NODE systemname="CreateEnum (Enumerations)" nodename="CreateEnum (Enumerations)" componentmode="Hidden" id="49">
+   <BOUNDS type="Node" left="12600" top="1440" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Enum Name" slicecount="1" values="OpenCV.CalibrateProjector.ProjectorCoordinates">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="50" systemname="IOBox (String)">
+   <BOUNDS type="Box" left="12615" top="825" width="1380" height="435">
+   </BOUNDS>
+   <BOUNDS type="Node" left="12615" top="825" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Input String" slicecount="2" values="|Normalised&cr;&lf;|,Pixels">
+   </PIN>
+   <PIN pinname="Default" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="File Mask" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Maximum Characters" slicecount="1" values="-1">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   <PIN pinname="Rows" slicecount="1" values="2">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="SliceCount Mode" slicecount="1" values="ColsRowsPages">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="50" srcpinname="Output String" dstnodeid="49" dstpinname="Strings">
+   </LINK>
+   <NODE systemname="NULL (Enumerations)" nodename="NULL (Enumerations)" componentmode="Hidden" id="51">
+   <BOUNDS type="Node" left="14820" top="1425" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Receive" slicecount="1" values="OpenCV.CalibrateProjector.ProjectorCoordinates">
+   </PIN>
+   <PIN pinname="Enum" slicecount="1" values="OpenCV.CalibrateProjector.ProjectorCoordinates">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (Enumerations)" componentmode="InABox" id="52" systemname="IOBox (Enumerations)">
+   <BOUNDS type="Box" left="13920" top="585" width="1590" height="240">
+   </BOUNDS>
+   <BOUNDS type="Node" left="13920" top="585" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Input Enum" slicecount="1" values="|Normalised&cr;&lf;|">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="|Input space|">
+   </PIN>
+   <PIN pinname="Output Enum" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="52" srcpinname="Output Enum" dstnodeid="51" dstpinname="Receive">
+   </LINK>
+   <NODE systemname="Enum2Ord (Enumerations)" nodename="Enum2Ord (Enumerations)" componentmode="Hidden" id="53">
+   <BOUNDS type="Node" left="13905" top="1425" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Enum" visible="1">
+   </PIN>
+   <PIN pinname="Ord Value" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="52" srcpinname="Output Enum" dstnodeid="53" dstpinname="Enum">
+   </LINK>
+   <NODE systemname="Switch (Value Input)" nodename="Switch (Value Input)" componentmode="Hidden" id="54">
+   <BOUNDS type="Node" left="810" top="2370" width="1470" height="270">
+   </BOUNDS>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <PIN pinname="Input 1" visible="1">
+   </PIN>
+   <PIN pinname="Input 2" visible="1">
+   </PIN>
+   <PIN pinname="Switch" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="24" srcpinname="Output" dstnodeid="54" dstpinname="Input 1">
+   </LINK>
+   <LINK srcnodeid="0" srcpinname="Y Output Value" dstnodeid="54" dstpinname="Input 2">
+   </LINK>
+   <LINK srcnodeid="53" srcpinname="Ord Value" dstnodeid="54" dstpinname="Switch" linkstyle="VHV" hiddenwhenlocked="1">
+   <LINKPOINT x="13905" y="2018">
+   </LINKPOINT>
+   <LINKPOINT x="870" y="2018">
+   </LINKPOINT>
+   </LINK>
+   <NODE systemname="Multiply (Transform)" nodename="Multiply (Transform)" componentmode="Hidden" id="60">
+   <BOUNDS type="Node" left="810" top="4635" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Transform In 1" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Transform Out" visible="1">
+   </PIN>
+   <PIN pinname="Transform In 2" visible="1" slicecount="1" values="||">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="60" srcpinname="Transform Out" dstnodeid="26" dstpinname="Transform" hiddenwhenlocked="1">
+   </LINK>
+   <LINK srcnodeid="60" srcpinname="Transform Out" dstnodeid="3" dstpinname="Input Node" linkstyle="VHV">
+   <LINKPOINT x="840" y="5325">
+   </LINKPOINT>
+   <LINKPOINT x="2760" y="5175">
+   </LINKPOINT>
+   </LINK>
+   <NODE systemname="Scale (Transform Vector)" nodename="Scale (Transform Vector)" componentmode="Hidden" id="61">
+   <BOUNDS type="Node" left="1065" top="4215" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Transform Out" visible="1">
+   </PIN>
+   <PIN pinname="Z">
+   </PIN>
+   <PIN pinname="Y">
+   </PIN>
+   <PIN pinname="X">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="61" srcpinname="Transform Out" dstnodeid="60" dstpinname="Transform In 2">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="63" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="1515" top="3360" width="330" height="720">
+   </BOUNDS>
+   <BOUNDS type="Node" left="1515" top="3360" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="3" values="1,-1,-1">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Vector Size" slicecount="1" values="3">
+   </PIN>
+   <PIN pinname="Rows" slicecount="1" values="3">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="63" srcpinname="Y Output Value" dstnodeid="61" dstpinname="XYZ">
+   </LINK>
+   <NODE nodename="IOBox (Enumerations)" componentmode="InABox" id="66" systemname="IOBox (Enumerations)">
+   <BOUNDS type="Box" left="9090" top="3135" width="1590" height="240">
+   </BOUNDS>
+   <BOUNDS type="Node" left="9090" top="3135" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Input Enum" slicecount="1" values="VVVV">
+   </PIN>
+   </NODE>
+   <NODE id="64" nodename="IOBox (Node)" componentmode="InABox" systemname="IOBox (Node)">
+   <BOUNDS type="Box" left="8040" top="630" width="795" height="240">
+   </BOUNDS>
+   <BOUNDS type="Node" left="8040" top="630" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Input Node" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="|Projection Transform|">
+   </PIN>
+   <PIN pinname="Output Node" visible="1">
+   </PIN>
+   </NODE>
+   <NODE id="65" systemname="SolvePnP (CV.Transform)" filename="..\..\..\plugins\VVVV.Nodes.OpenCV.dll" nodename="SolvePnP (CV.Transform)" componentmode="Hidden">
+   <BOUNDS type="Node" left="2070" top="3705" width="8475" height="270">
+   </BOUNDS>
+   <PIN pinname="Image PointsXY" visible="1">
+   </PIN>
+   <PIN pinname="Object PointsXYZ" visible="1">
+   </PIN>
+   <PIN pinname="Do" visible="1">
+   </PIN>
+   <PIN pinname="Status" visible="1">
+   </PIN>
+   <PIN pinname="Intrinsics" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="View per board" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="65" srcpinname="View per board" dstnodeid="60" dstpinname="Transform In 1">
+   </LINK>
+   <LINK srcnodeid="65" srcpinname="Status" dstnodeid="8" dstpinname="Input String">
+   </LINK>
+   <LINK srcnodeid="10" srcpinname="Y Output Value" dstnodeid="65" dstpinname="Do">
+   </LINK>
+   <LINK srcnodeid="66" srcpinname="Output Enum" dstnodeid="65" dstpinname="Coordinates">
+   </LINK>
+   <LINK srcnodeid="1" srcpinname="Y Output Value" dstnodeid="65" dstpinname="Object PointsXYZ">
+   </LINK>
+   <LINK srcnodeid="54" srcpinname="Output" dstnodeid="65" dstpinname="Image PointsXY">
+   </LINK>
+   <NODE systemname="Intrinsics (CV.Transform Join)" filename="..\..\..\plugins\VVVV.Nodes.OpenCV.dll" nodename="Intrinsics (CV.Transform Join)" componentmode="Hidden" id="67">
+   <BOUNDS type="Node" left="7320" top="1410" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Sensor SizeXY" visible="1">
+   </PIN>
+   <PIN pinname="VVVV Projection Transform" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Intrinsics" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="18" srcpinname="Y Output Value" dstnodeid="67" dstpinname="Sensor SizeXY">
+   </LINK>
+   <LINK srcnodeid="64" srcpinname="Output Node" dstnodeid="67" dstpinname="VVVV Projection Transform">
+   </LINK>
+   <LINK srcnodeid="67" srcpinname="Intrinsics" dstnodeid="65" dstpinname="Intrinsics">
+   </LINK>
+   </PATCH>

--- a/src/nodes/plugins/Image/OpenCV/VVVV.CV.Nodes.csproj
+++ b/src/nodes/plugins/Image/OpenCV/VVVV.CV.Nodes.csproj
@@ -107,6 +107,7 @@
     <Compile Include="src\Calibration\FindBoardInstance.cs" />
     <Compile Include="src\Calibration\FindBoardNode.cs" />
     <Compile Include="src\Calibration\IntrinsicsSplitNode.cs" />
+    <Compile Include="src\Calibration\IntrinsicsJoinNode.cs" /> 
     <Compile Include="src\Calibration\ProjectPointsNode.cs" />
     <None Include="packages.config" />
     <None Include="src\Features\Stitch.cs" />

--- a/src/nodes/plugins/Image/OpenCV/src/Calibration/IntrinsicsJoinNode.cs
+++ b/src/nodes/plugins/Image/OpenCV/src/Calibration/IntrinsicsJoinNode.cs
@@ -1,0 +1,87 @@
+﻿#region usings
+using System;
+using System.ComponentModel.Composition;
+using System.Drawing;
+using System.Threading;
+
+using VVVV.PluginInterfaces.V1;
+using VVVV.PluginInterfaces.V2;
+using VVVV.Utils.VMath;
+using VVVV.Core.Logging;
+
+using Emgu.CV;
+using Emgu.CV.Structure;
+using Emgu.CV.CvEnum;
+using ThreadState = System.Threading.ThreadState;
+using System.Collections.Generic;
+
+#endregion usings
+
+namespace VVVV.CV.Nodes
+{
+
+	#region PluginInfo
+	[PluginInfo(Name = "Intrinsics", Category = "CV.Transform", Version = "Join", Help = "Join intrinsics params", Tags = "")]
+	#endregion PluginInfo
+	public class IntrinsicsJoinNode : IPluginEvaluate, IDisposable
+	{
+		#region fields & pins
+
+        [Input("Sensor Size")]
+        ISpread<Vector2D> FPinInSensorSize;
+
+        [Input("VVVV Projection Transform")]
+        ISpread<Matrix4x4> FPinInCameraTransform;
+
+        [Input("Distortion Coefficients")]
+        ISpread<ISpread<Double>> FPinInDistiortonCoefficients;
+
+		[Output("Intrinsics")]
+        ISpread<Intrinsics> FPinOutIntrinsics;
+
+
+
+		[Import]
+		ILogger FLogger;
+
+		#endregion fields & pins
+
+		[ImportingConstructor]
+        public IntrinsicsJoinNode(IPluginHost host)
+		{
+
+		}
+
+		public void Dispose()
+		{
+		}
+
+		//called when data for any output pin is requested
+		public void Evaluate(int SpreadMax)
+		{
+			//if (!FPinInIntrinsics.IsChanged)
+			//    return;
+
+            if (FPinInCameraTransform[0] == null)
+			{
+                FPinOutIntrinsics.SliceCount = 0;
+			}
+			else
+			{
+                FPinOutIntrinsics.SliceCount = SpreadMax;
+
+				for (int i = 0; i < SpreadMax; i++)
+				{
+                    IntrinsicCameraParameters cp = new IntrinsicCameraParameters();
+                    // Inspiration / details from http://strawlab.org/2011/11/05/augmented-reality-with-OpenGL/ - See Intrinsics.cs too
+                    cp.IntrinsicMatrix[0, 0] = FPinInCameraTransform[i][0, 0] * FPinInSensorSize[i].x / 2;// =L15*P8/2
+                    cp.IntrinsicMatrix[1, 1] = FPinInCameraTransform[i][1, 1] * FPinInSensorSize[i].y / 2;// =L15*P8/2
+                    cp.IntrinsicMatrix[0, 2] = (FPinInCameraTransform[i][2, 0] + 1)* FPinInSensorSize[i].x / 2;// =L15*P8/2
+                    cp.IntrinsicMatrix[1, 2] = (FPinInCameraTransform[i][2, 1] +1) * FPinInSensorSize[i].y / 2;// =L15*P8/2
+                    cp.IntrinsicMatrix[2, 2] = 1;
+                    FPinOutIntrinsics[i] = new Intrinsics(cp, new Size((int)FPinInSensorSize[i].x, (int)FPinInSensorSize[i].y));
+				}
+			}
+		}
+	}
+}

--- a/src/nodes/plugins/Image/OpenCV/src/Calibration/SolvePnP.cs
+++ b/src/nodes/plugins/Image/OpenCV/src/Calibration/SolvePnP.cs
@@ -20,6 +20,8 @@ using VVVV.CV.Core;
 
 namespace VVVV.CV.Nodes
 {
+	public enum TCoordinateSystem { VVVV, OpenCV };
+
 	#region PluginInfo
 	[PluginInfo(Name = "SolvePnP", Category = "CV.Transform", Help = "Find extrinsics of object given camera intrinsics and some image<>object correspondences", Tags = "FindExtrinsics")]
 	#endregion PluginInfo
@@ -27,7 +29,7 @@ namespace VVVV.CV.Nodes
 	{
 		#region fields & pins
 		[Input("Object Points")]
-		ISpread<ISpread<Vector3D> > FPinInObject;
+		ISpread<ISpread<Vector3D>> FPinInObject;
 
 		[Input("Image Points")]
 		ISpread<ISpread<Vector2D>> FPinInImage;
@@ -35,8 +37,17 @@ namespace VVVV.CV.Nodes
 		[Input("Intrinsics")]
 		ISpread<Intrinsics> FPinInIntrinsics;
 
+		[Input("Coordinates", IsSingle = true)]
+		ISpread<TCoordinateSystem> FPinInCoordSystem;
+
+		[Input("Do", IsBang = true, IsSingle = true)]
+		ISpread<bool> FPinInDo;
+
 		[Output("Extrinsics")]
 		ISpread<Extrinsics> FPinOutExtrinsics;
+
+		[Output("View per board")]
+		ISpread<Matrix4x4> FPinOutView;
 
 		[Output("Status")]
 		ISpread<String> FPinOutStatus;
@@ -49,7 +60,6 @@ namespace VVVV.CV.Nodes
 		[ImportingConstructor]
 		public SolvePnPNode(IPluginHost host)
 		{
-
 		}
 
 		public void Dispose()
@@ -60,33 +70,43 @@ namespace VVVV.CV.Nodes
 		//called when data for any output pin is requested
 		public void Evaluate(int SpreadMax)
 		{
-			SpreadMax = Math.Max(FPinInObject.SliceCount, FPinInImage.SliceCount);
-
-			FPinOutExtrinsics.SliceCount = SpreadMax;
-			FPinOutStatus.SliceCount = SpreadMax;
-
-			for (int i = 0; i < SpreadMax; i++)
+			if (FPinInDo[0])
 			{
-				try
-				{
-					if (FPinInObject[i].SliceCount == 0 || FPinInImage[i].SliceCount == 0)
-						throw new Exception("No datapoints");
-					if (FPinInImage[i].SliceCount == 1)
-						throw new Exception("Only 1 image point is being input per board, check SliceCount!");
-					if (FPinInObject[i].SliceCount == 1)
-						throw new Exception("Only 1 object point is being input per board, check SliceCount!");
-					if (FPinInIntrinsics[i].intrinsics == null)
-						throw new Exception("Waiting for camera calibration intrinsics");
+				bool useVVVVCoords = FPinInCoordSystem[0] == TCoordinateSystem.VVVV;
 
-					ExtrinsicCameraParameters extrinsics = CameraCalibration.FindExtrinsicCameraParams2(MatrixUtils.ObjectPoints(FPinInObject[i], true), MatrixUtils.ImagePoints(FPinInImage[i]), FPinInIntrinsics[i].intrinsics);
-					FPinOutExtrinsics[i] = new Extrinsics(extrinsics);
-					FPinOutStatus[i] = "OK";
-				}
-				catch (Exception e)
+				SpreadMax = Math.Max(FPinInObject.SliceCount, FPinInImage.SliceCount);
+
+				FPinOutExtrinsics.SliceCount = SpreadMax;
+				FPinOutStatus.SliceCount = SpreadMax;
+
+				for (int i = 0; i < SpreadMax; i++)
 				{
-					FPinOutStatus[i] = e.Message;
+					try
+					{
+						if (FPinInObject[i].SliceCount == 0 || FPinInImage[i].SliceCount == 0)
+							throw new Exception("No datapoints");
+						if (FPinInImage[i].SliceCount == 1)
+							throw new Exception("Only 1 image point is being input per board, check SliceCount!");
+						if (FPinInObject[i].SliceCount == 1)
+							throw new Exception("Only 1 object point is being input per board, check SliceCount!");
+						if (FPinInIntrinsics[i].intrinsics == null)
+							throw new Exception("Waiting for camera calibration intrinsics");
+
+						ExtrinsicCameraParameters extrinsics = CameraCalibration.FindExtrinsicCameraParams2(MatrixUtils.ObjectPoints(FPinInObject[i], useVVVVCoords), MatrixUtils.ImagePoints(FPinInImage[i]), FPinInIntrinsics[i].intrinsics);
+						FPinOutExtrinsics[i] = new Extrinsics(extrinsics);
+
+						if (useVVVVCoords)
+							FPinOutView[i] = MatrixUtils.ConvertToVVVV(FPinOutExtrinsics[i].Matrix);
+						else
+							FPinOutView[i] = FPinOutExtrinsics[i].Matrix;
+
+						FPinOutStatus[i] = "OK";
+					}
+					catch (Exception e)
+					{
+						FPinOutStatus[i] = e.Message;
+					}
 				}
-				
 			}
 		}
 	}


### PR DESCRIPTION
Hi Elliot,

Just wanted to say thank you for all the work you're doing with OpenCV and vvvv, and to share that I have been using it successfully to calibrate / reposition fixed focal projectors for a projection mapping project.

Because of the fixed focal, I ended up using and making small changes to the SolvePnP node, to make it work more like CalibrateCamera, and also hacked an "IntrinsicsJoin" node to be able to user vvvv matrices as input to solvepnp (which turned out quite useful as the guess input for CalibrateCamera too).

Those changes are rebased in this commit, feel free to use any of it if it can help

/Benjamin 
